### PR TITLE
Update nodejs runtime as 12.x is no longer supported

### DIFF
--- a/generate-devopsguru-insights/cfn-shops-monitoroper-code.yaml
+++ b/generate-devopsguru-insights/cfn-shops-monitoroper-code.yaml
@@ -85,7 +85,7 @@ Resources:
         Fn::GetAtt:
           - LambdaServiceRoleMonitorOper
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           TABLE_NAME:
@@ -187,7 +187,7 @@ Resources:
         Fn::GetAtt:
           - Lambda2ServiceRoleMonitorOper
           - Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           TABLE_NAME:


### PR DESCRIPTION
Cloudformation deployment of file `cfn-shops-monitoroper-code.yaml` errors out with

> The runtime parameter of nodejs12.x is no longer supported for creating or updating AWS Lambda functions.

Updating to `nodejs16.x`.

Not using `nodejs18.x` as this would require additional code changes; 18.x only supports the newer aws-sdk 3 (see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). With 18.x the 'LambdaToListShops' fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
